### PR TITLE
Faster Flatten Grad & Params Procedure

### DIFF
--- a/neurips22/src/dmsort/utils.py
+++ b/neurips22/src/dmsort/utils.py
@@ -40,29 +40,15 @@ def compute_avg_grad_error(args,
         index += 1
     tb_logger.add_scalar('train/metric', cur_var, epoch)
 
-
 def flatten_grad(optimizer):
-    t = None
+    t = []
     for _, param_group in enumerate(optimizer.param_groups):
         for p in param_group['params']:
-            if p.grad is not None:
-                if t is None:
-                    t = torch.flatten(p.grad.data)
-                else:
-                    t = torch.cat(
-                        (t, torch.flatten(p.grad.data))
-                    )
-    return t
-
+            if p.grad is not None: t.append(p.grad.data.view(-1))
+    return torch.concat(t)
 
 def flatten_params(model):
-    t = None
+    t = []
     for _, param in enumerate(model.parameters()):
-        if param is not None:
-            if t is None:
-                t = torch.flatten(param.data)
-            else:
-                t = torch.cat(
-                    (t, torch.flatten(param.data))
-                )
-    return t
+        if param is not None: t.append(param.data.view(-1))
+    return torch.concat(t)


### PR DESCRIPTION
The previous repeated concatenation & flattening approach will make the GraB significantly slower for model that has a lot of param groups. i.e. `bert-base-uncased`, and this is the performance bottleneck for finetuning foundation model with GraB.
Basically the time complexity is **quadratic** to the number of param groups, and we want a linear time complexity here.

The new appraoch will improve the speed of GraB remarkably with large model. For benchmarking, it will take 20-30 minutes for finetuning on GLUE tasks while previously it will take 3+ hours.